### PR TITLE
feat: naver, kakao, google 소셜 로그인 기능 구현구현 #2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# webstorm
+.idea

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,19 +23,20 @@ model Example {
 
 // Necessary for Next auth
 model Account {
-    id                String  @id @default(cuid())
-    userId            String
-    type              String
-    provider          String
-    providerAccountId String
-    refresh_token     String? @db.Text
-    access_token      String? @db.Text
-    expires_at        Int?
-    token_type        String?
-    scope             String?
-    id_token          String? @db.Text
-    session_state     String?
-    user              User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+    id                       String  @id @default(cuid())
+    userId                   String
+    type                     String
+    provider                 String
+    providerAccountId        String
+    refresh_token            String? @db.Text
+    access_token             String? @db.Text
+    expires_at               Int?
+    refresh_token_expires_in Int?
+    token_type               String?
+    scope                    String?
+    id_token                 String? @db.Text
+    session_state            String?
+    user                     User    @relation(fields: [userId], references: [id], onDelete: Cascade)
 
     @@unique([provider, providerAccountId])
     @@index([userId])

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -27,6 +27,8 @@ export const env = createEnv({
     NAVER_CLIENT_SECRET: z.string(),
     KAKAO_CLIENT_ID: z.string(),
     KAKAO_CLIENT_SECRET: z.string(),
+    GOOGLE_CLIENT_ID: z.string(),
+    GOOGLE_CLIENT_SECRET: z.string(),
   },
 
   /**
@@ -53,5 +55,7 @@ export const env = createEnv({
     NAVER_CLIENT_SECRET: process.env.NAVER_CLIENT_SECRET,
     KAKAO_CLIENT_ID: process.env.KAKAO_CLIENT_ID,
     KAKAO_CLIENT_SECRET: process.env.KAKAO_CLIENT_SECRET,
+    GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID,
+    GOOGLE_CLIENT_SECRET: process.env.GOOGLE_CLIENT_SECRET,
   },
 });

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -24,7 +24,9 @@ export const env = createEnv({
     DISCORD_CLIENT_ID: z.string(),
     DISCORD_CLIENT_SECRET: z.string(),
     NAVER_CLIENT_ID: z.string(),
-    NAVER_CLIENT_SECRET: z.string()
+    NAVER_CLIENT_SECRET: z.string(),
+    KAKAO_CLIENT_ID: z.string(),
+    KAKAO_CLIENT_SECRET: z.string(),
   },
 
   /**
@@ -49,5 +51,7 @@ export const env = createEnv({
     DISCORD_CLIENT_SECRET: process.env.DISCORD_CLIENT_SECRET,
     NAVER_CLIENT_ID: process.env.NAVER_CLIENT_ID,
     NAVER_CLIENT_SECRET: process.env.NAVER_CLIENT_SECRET,
+    KAKAO_CLIENT_ID: process.env.KAKAO_CLIENT_ID,
+    KAKAO_CLIENT_SECRET: process.env.KAKAO_CLIENT_SECRET,
   },
 });

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -21,8 +21,6 @@ export const env = createEnv({
       process.env.VERCEL ? z.string().min(1) : z.string().url(),
     ),
     // Add `.min(1) on ID and SECRET if you want to make sure they're not empty
-    DISCORD_CLIENT_ID: z.string(),
-    DISCORD_CLIENT_SECRET: z.string(),
     NAVER_CLIENT_ID: z.string(),
     NAVER_CLIENT_SECRET: z.string(),
     KAKAO_CLIENT_ID: z.string(),
@@ -49,8 +47,6 @@ export const env = createEnv({
     NODE_ENV: process.env.NODE_ENV,
     NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET,
     NEXTAUTH_URL: process.env.NEXTAUTH_URL,
-    DISCORD_CLIENT_ID: process.env.DISCORD_CLIENT_ID,
-    DISCORD_CLIENT_SECRET: process.env.DISCORD_CLIENT_SECRET,
     NAVER_CLIENT_ID: process.env.NAVER_CLIENT_ID,
     NAVER_CLIENT_SECRET: process.env.NAVER_CLIENT_SECRET,
     KAKAO_CLIENT_ID: process.env.KAKAO_CLIENT_ID,

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -23,6 +23,8 @@ export const env = createEnv({
     // Add `.min(1) on ID and SECRET if you want to make sure they're not empty
     DISCORD_CLIENT_ID: z.string(),
     DISCORD_CLIENT_SECRET: z.string(),
+    NAVER_CLIENT_ID: z.string(),
+    NAVER_CLIENT_SECRET: z.string()
   },
 
   /**
@@ -45,5 +47,7 @@ export const env = createEnv({
     NEXTAUTH_URL: process.env.NEXTAUTH_URL,
     DISCORD_CLIENT_ID: process.env.DISCORD_CLIENT_ID,
     DISCORD_CLIENT_SECRET: process.env.DISCORD_CLIENT_SECRET,
+    NAVER_CLIENT_ID: process.env.NAVER_CLIENT_ID,
+    NAVER_CLIENT_SECRET: process.env.NAVER_CLIENT_SECRET,
   },
 });

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -5,6 +5,7 @@ import {
   type DefaultSession,
 } from "next-auth";
 import DiscordProvider from "next-auth/providers/discord";
+import NaverProvider from "next-auth/providers/naver";
 import { PrismaAdapter } from "@next-auth/prisma-adapter";
 import { env } from "~/env.mjs";
 import { prisma } from "~/server/db";
@@ -50,6 +51,10 @@ export const authOptions: NextAuthOptions = {
     DiscordProvider({
       clientId: env.DISCORD_CLIENT_ID,
       clientSecret: env.DISCORD_CLIENT_SECRET,
+    }),
+    NaverProvider({
+      clientId: env.NAVER_CLIENT_ID,
+      clientSecret: env.NAVER_CLIENT_SECRET,
     }),
     /**
      * ...add more providers here.

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -6,6 +6,7 @@ import {
 } from "next-auth";
 import DiscordProvider from "next-auth/providers/discord";
 import NaverProvider from "next-auth/providers/naver";
+import KakaoProvider from "next-auth/providers/kakao";
 import { PrismaAdapter } from "@next-auth/prisma-adapter";
 import { env } from "~/env.mjs";
 import { prisma } from "~/server/db";
@@ -55,6 +56,10 @@ export const authOptions: NextAuthOptions = {
     NaverProvider({
       clientId: env.NAVER_CLIENT_ID,
       clientSecret: env.NAVER_CLIENT_SECRET,
+    }),
+    KakaoProvider({
+      clientId: env.KAKAO_CLIENT_ID,
+      clientSecret: env.KAKAO_CLIENT_SECRET,
     }),
     /**
      * ...add more providers here.

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -4,7 +4,6 @@ import {
   type NextAuthOptions,
   type DefaultSession,
 } from "next-auth";
-import DiscordProvider from "next-auth/providers/discord";
 import NaverProvider from "next-auth/providers/naver";
 import KakaoProvider from "next-auth/providers/kakao";
 import GoogleProvider from "next-auth/providers/google";
@@ -50,10 +49,6 @@ export const authOptions: NextAuthOptions = {
   },
   adapter: PrismaAdapter(prisma),
   providers: [
-    DiscordProvider({
-      clientId: env.DISCORD_CLIENT_ID,
-      clientSecret: env.DISCORD_CLIENT_SECRET,
-    }),
     NaverProvider({
       clientId: env.NAVER_CLIENT_ID,
       clientSecret: env.NAVER_CLIENT_SECRET,

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -7,6 +7,7 @@ import {
 import DiscordProvider from "next-auth/providers/discord";
 import NaverProvider from "next-auth/providers/naver";
 import KakaoProvider from "next-auth/providers/kakao";
+import GoogleProvider from "next-auth/providers/google";
 import { PrismaAdapter } from "@next-auth/prisma-adapter";
 import { env } from "~/env.mjs";
 import { prisma } from "~/server/db";
@@ -60,6 +61,10 @@ export const authOptions: NextAuthOptions = {
     KakaoProvider({
       clientId: env.KAKAO_CLIENT_ID,
       clientSecret: env.KAKAO_CLIENT_SECRET,
+    }),
+    GoogleProvider({
+      clientId: env.GOOGLE_CLIENT_ID,
+      clientSecret: env.GOOGLE_CLIENT_SECRET,
     }),
     /**
      * ...add more providers here.


### PR DESCRIPTION
Closes #2 
- 소셜 로그인 기능을 구현했습니다.  
- https://daldang-git-feat-2-social-login-daldang.vercel.app
- 로그인 한번 해보시고 안되면 말씀해주세요
- localhost:3000 도 callback URL 설정을 했기 때문에 로컬 빌드에서도 문제가 없을 겁니다. 
    - .env 파일 수정이 필요한데, 이건 slack 으로 전달해 드리겠습니다. 
- Oauth 개발자 콘솔에 개발자 초대는 구글만 먼저 했습니다. 네이버 카카오는 안되더라구요.. 설정 변경이 필요하시면 저한테 말씀해주세요. 제가 반영하겠습니다  
- Log in [Sign-in URL](https://daldang-l0is181y2-daldang.vercel.app/api/auth/signin?callbackUrl=https://daldang-l0is181y2-daldang.vercel.app/)

# Preview
![image](https://github.com/daldang/daldang/assets/41039751/374dd52f-83e8-4299-84a5-ddf1834531ea)

