### PR TITLE
feat: Implements desert log router 

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -72,7 +72,7 @@ model User {
     image         String?
     accounts      Account[]
     sessions      Session[]
-    DesertLog     DesertLog[]
+    desertLogs    DesertLog[]
 }
 
 model VerificationToken {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,6 +21,18 @@ model Example {
     updatedAt DateTime @updatedAt
 }
 
+model DesertLog {
+    id        String   @id @default(cuid())
+    date      DateTime @default(now())
+    content   String   @db.Text
+    authorId  String
+    author    User     @relation(fields: [authorId], references: [id], onDelete: Cascade)
+    createdAt DateTime @default(now())
+    updatedAt DateTime @updatedAt
+
+    @@index([authorId])
+}
+
 // Necessary for Next auth
 model Account {
     id                       String  @id @default(cuid())
@@ -53,13 +65,14 @@ model Session {
 }
 
 model User {
-    id            String    @id @default(cuid())
+    id            String      @id @default(cuid())
     name          String?
-    email         String?   @unique
+    email         String?     @unique
     emailVerified DateTime?
     image         String?
     accounts      Account[]
     sessions      Session[]
+    DesertLog     DesertLog[]
 }
 
 model VerificationToken {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -60,7 +60,7 @@ const AuthShowcase: React.FC = () => {
   const { data: sessionData } = useSession();
 
   const { data: desertLogs } = api.desertLog.getAllDesertLogs.useQuery(
-    undefined,
+    {authorId: sessionData?.user.id || ""},
     {enabled: sessionData?.user !== undefined }
   );
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -59,16 +59,16 @@ export default Home;
 const AuthShowcase: React.FC = () => {
   const { data: sessionData } = useSession();
 
-  const { data: secretMessage } = api.example.getSecretMessage.useQuery(
-    undefined, // no input
-    { enabled: sessionData?.user !== undefined }
+  const { data: desertLogs } = api.desertLog.getAllDesertLogs.useQuery(
+    undefined,
+    {enabled: sessionData?.user !== undefined }
   );
 
   return (
     <div className="flex flex-col items-center justify-center gap-4">
       <p className="text-center text-2xl text-slate-500">
         {sessionData && <span>Logged in as {sessionData.user?.name}</span>}
-        {secretMessage && <span> - {secretMessage}</span>}
+        {desertLogs?.map((log) => <div key={log.id}>{ log.content}</div>)}
       </p>
       <button
         className="rounded-fullpx-10 bg-red-100 py-3 font-semibold text-slate-500 no-underline"

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -1,5 +1,6 @@
 import { createTRPCRouter } from "~/server/api/trpc";
 import { exampleRouter } from "~/server/api/routers/example";
+import { desertLogRouter } from "./routers/desertLogs";
 
 /**
  * This is the primary router for your server.
@@ -8,6 +9,7 @@ import { exampleRouter } from "~/server/api/routers/example";
  */
 export const appRouter = createTRPCRouter({
   example: exampleRouter,
+  desertLog: desertLogRouter,
 });
 
 // export type definition of API

--- a/src/server/api/routers/desertLogs.ts
+++ b/src/server/api/routers/desertLogs.ts
@@ -16,11 +16,28 @@ export const desertLogRouter = createTRPCRouter({
 
   createDesertLog: protectedProcedure
     .input(z.object({ content: z.string(), date: z.date() }))
-    .query(({ ctx, input }) => {
+    .mutation(({ ctx, input }) => {
       return ctx.prisma.desertLog.create({
         data: {
           authorId: ctx.session.user.id,
           content: input.content,
+        },
+      });
+    }),
+
+  deleteDesertLog: protectedProcedure
+    .input(z.object({ desertLogId: z.string() }))
+    .mutation(({ ctx, input }) => {
+      return ctx.prisma.user.update({
+        where: {
+          id: ctx.session.user.id,
+        },
+        data: {
+          desertLogs: {
+            deleteMany: {
+              id: input.desertLogId,
+            },
+          },
         },
       });
     }),

--- a/src/server/api/routers/desertLogs.ts
+++ b/src/server/api/routers/desertLogs.ts
@@ -15,22 +15,24 @@ export const desertLogRouter = createTRPCRouter({
   }),
 
   createDesertLog: protectedProcedure
-    .input(z.object({ content: z.string(), date: z.date() }))
+    .input(
+      z.object({ authorId: z.string(), content: z.string(), date: z.date() })
+    )
     .mutation(({ ctx, input }) => {
       return ctx.prisma.desertLog.create({
         data: {
-          authorId: ctx.session.user.id,
+          authorId: input.authorId,
           content: input.content,
         },
       });
     }),
 
   deleteDesertLog: protectedProcedure
-    .input(z.object({ desertLogId: z.string() }))
+    .input(z.object({ authorId: z.string(), desertLogId: z.string() }))
     .mutation(({ ctx, input }) => {
       return ctx.prisma.user.update({
         where: {
-          id: ctx.session.user.id,
+          id: input.authorId,
         },
         data: {
           desertLogs: {

--- a/src/server/api/routers/desertLogs.ts
+++ b/src/server/api/routers/desertLogs.ts
@@ -1,0 +1,16 @@
+import { contextProps } from "@trpc/react-query/shared";
+import { z } from "zod";
+
+import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+
+export const desertLogRouter = createTRPCRouter({
+  getAllDesertLogs: protectedProcedure.query(({ ctx }) => {
+    return ctx.prisma.desertLog.findMany({
+      where: {
+        authorId: {
+          equals: ctx.session.user.id,
+        },
+      },
+    });
+  }),
+});

--- a/src/server/api/routers/desertLogs.ts
+++ b/src/server/api/routers/desertLogs.ts
@@ -4,15 +4,17 @@ import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 
 export const desertLogRouter = createTRPCRouter({
-  getAllDesertLogs: protectedProcedure.query(({ ctx }) => {
-    return ctx.prisma.desertLog.findMany({
-      where: {
-        authorId: {
-          equals: ctx.session.user.id,
+  getAllDesertLogs: protectedProcedure
+    .input(z.object({ authorId: z.string() }))
+    .query(({ ctx }) => {
+      return ctx.prisma.desertLog.findMany({
+        where: {
+          authorId: {
+            equals: ctx.session.user.id,
+          },
         },
-      },
-    });
-  }),
+      });
+    }),
 
   createDesertLog: protectedProcedure
     .input(

--- a/src/server/api/routers/desertLogs.ts
+++ b/src/server/api/routers/desertLogs.ts
@@ -13,4 +13,15 @@ export const desertLogRouter = createTRPCRouter({
       },
     });
   }),
+
+  createDesertLog: protectedProcedure
+    .input(z.object({ content: z.string(), date: z.date() }))
+    .query(({ ctx, input }) => {
+      return ctx.prisma.desertLog.create({
+        data: {
+          authorId: ctx.session.user.id,
+          content: input.content,
+        },
+      });
+    }),
 });


### PR DESCRIPTION
Closes #6 

DesertLog 의 읽기, 쓰기, 삭제 기능을 구현했습니다.
사용법은 이미 존재하는 example router 와 동일하고, pages/index.ts 의 `AuthShowcase` 컴포넌트를 확인하시면 될 것 같습니다. 

- feat: Implements `getAllDesertLogs`
- feat: Implements `createDesertLog`
- feat: Implements deleteDesertLog
