### PR TITLE
feat: Add location by text input

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,6 +29,7 @@ model DesertLog {
     content         String   @db.Text
     image           String?  @db.Text
     score           Int      @default(0)
+    location        String   @db.Text
     authorId        String
     author          User     @relation(fields: [authorId], references: [id], onDelete: Cascade)
 

--- a/src/pages/record/add.tsx
+++ b/src/pages/record/add.tsx
@@ -73,7 +73,7 @@ const RecordAddPage: NextPage = () => {
             width={150}
             height={150}
           />
-          <div className="flex-col bg-slate-50">
+          <div className="flex-col">
             <div className="py-1 text-2xl">{request.desertName}</div>
             <time className="py-1 text-center">
               {request.date.toDateString()}
@@ -91,9 +91,13 @@ const RecordAddPage: NextPage = () => {
                   fill="#FF6562"
                 />
               </svg>
-              <div className="p-1 text-center text-primary">
-                서울 특별시 합정동
-              </div>
+              <input
+                className="p-1 text-center text-primary"
+                placeholder="위치를 입력하세요"
+                onChange={(e) =>
+                  setRequest({ ...request, location: e.target.value })
+                }
+              ></input>
             </div>
           </div>
         </div>

--- a/src/pages/records/[id].tsx
+++ b/src/pages/records/[id].tsx
@@ -82,7 +82,7 @@ const RecordPage = () => {
             </div>
           </div>
           <div className="flex justify-between p-5">
-            <div className="text-[#9C9C67]"> 서울특별시 합정동</div>
+            <div className="text-[#9C9C67]">{record.location}</div>
             <div>{record.date.toDateString().replaceAll("/", ".")}</div>
           </div>
           <div className="p-5">{record.content}</div>

--- a/src/server/api/routers/desertLogs.ts
+++ b/src/server/api/routers/desertLogs.ts
@@ -37,6 +37,7 @@ export const desertLogRouter = createTRPCRouter({
         desertName: z.string(),
         score: z.number(),
         image: z.string(),
+        location: z.string(),
       })
     )
     .mutation(({ ctx, input }) => {
@@ -48,6 +49,7 @@ export const desertLogRouter = createTRPCRouter({
           desertName: input.desertName,
           desertCharacter: input.desertCharacter,
           image: input.image,
+          location: input.location,
         },
       });
     }),

--- a/src/utils/hook.ts
+++ b/src/utils/hook.ts
@@ -16,6 +16,7 @@ export function useSessionStorageRequestState() {
       desertCharacter: "",
       score: 50,
       image: "",
+      location: "",
     },
     serializer: SuperJSON,
   });


### PR DESCRIPTION
카카오지도 API 를 제외하고, 텍스트 인풋으로만 위치를 추가할 수 있도록 구현했습니다. 
- DB 스키마 변경이 있었기 때문에, 로컬에서는 `npm install` 을 실행해주시고, `npm run dev` 를 다시 실행해야 합니다. 