### PR TITLE
feat: Add redirection helper function with session

### DIFF
--- a/src/pages/record/add.tsx
+++ b/src/pages/record/add.tsx
@@ -1,5 +1,7 @@
-import { type NextPage } from "next";
-import { useSession } from "next-auth/react";
+import {
+  type GetServerSidePropsContext,
+  type InferGetServerSidePropsType,
+} from "next";
 import { useS3Upload } from "next-s3-upload";
 import Head from "next/head";
 import Image from "next/image";
@@ -7,13 +9,14 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import { useState } from "react";
 import { ButtonPrimary } from "~/components/Button";
+import { getServerSideSessionPropsOrRedirect } from "~/server/auth";
 import { api } from "~/utils/api";
 import { useSessionStorageRequestState } from "~/utils/hook";
 
-const RecordAddPage: NextPage = () => {
+export default function RecordAddPage({
+  sessionData,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
-
-  const { data: sessionData } = useSession();
 
   const [imageFile, setImageFile] = useState<File | undefined>();
   const [objectURL, setObjectURL] = useState<string | undefined>();
@@ -145,6 +148,8 @@ const RecordAddPage: NextPage = () => {
       </div>
     </>
   );
-};
+}
 
-export default RecordAddPage;
+export async function getServerSideProps(context: GetServerSidePropsContext) {
+  return getServerSideSessionPropsOrRedirect(context);
+}

--- a/src/pages/record/index.tsx
+++ b/src/pages/record/index.tsx
@@ -1,12 +1,18 @@
-import { type NextPage } from "next";
+import {
+  type GetServerSidePropsContext,
+  type InferGetServerSidePropsType,
+} from "next";
 import Head from "next/head";
 import Image from "next/image";
 import Link from "next/link";
 import { ButtonPrimary, ButtonSecondary } from "~/components/Button";
+import { getServerSideSessionPropsOrRedirect } from "~/server/auth";
 import { useSessionStorageRequestState } from "~/utils/hook";
 import { arrayDesertCharacter, type DesertCharacter } from "~/utils/type";
 
-const RecordPage: NextPage = () => {
+export default function RecordPage({}: InferGetServerSidePropsType<
+  typeof getServerSideProps
+>) {
   const [request, setRequest] = useSessionStorageRequestState();
   const handleSelecet = (charSelected: DesertCharacter) => {
     setRequest({ ...request, desertCharacter: charSelected });
@@ -65,9 +71,7 @@ const RecordPage: NextPage = () => {
       </div>
     </>
   );
-};
-
-export default RecordPage;
+}
 
 const DesertCharacterImage = ({
   char,
@@ -112,3 +116,7 @@ const sizeFromDesertCharacter = (char: DesertCharacter) => {
       return { width: 95.76, height: 82.47 };
   }
 };
+
+export async function getServerSideProps(context: GetServerSidePropsContext) {
+  return getServerSideSessionPropsOrRedirect(context);
+}

--- a/src/pages/records/[id].tsx
+++ b/src/pages/records/[id].tsx
@@ -1,14 +1,19 @@
-import { useSession } from "next-auth/react";
+import {
+  type GetServerSidePropsContext,
+  type InferGetServerSidePropsType,
+} from "next";
 import Head from "next/head";
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { ButtonPrimary, ButtonSecondary } from "~/components/Button";
+import { getServerSideSessionPropsOrRedirect } from "~/server/auth";
 import { api } from "~/utils/api";
 
-const RecordPage = () => {
+export default function RecordsPage({
+  sessionData,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
-  const { data: sessionData } = useSession();
   const record = api.desertLog.getDesertLogById.useQuery({
     id: router.query.id as string,
   }).data;
@@ -94,6 +99,8 @@ const RecordPage = () => {
       </div>
     </>
   );
-};
+}
 
-export default RecordPage;
+export async function getServerSideProps(context: GetServerSidePropsContext) {
+  return getServerSideSessionPropsOrRedirect(context);
+}

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -87,3 +87,17 @@ export const getServerAuthSession = (ctx: {
 }) => {
   return getServerSession(ctx.req, ctx.res, authOptions);
 };
+
+export async function getServerSideSessionPropsOrRedirect(
+  context: GetServerSidePropsContext
+) {
+  const session = await getServerAuthSession(context);
+
+  if (!session) {
+    return { redirect: { destination: "/signin" } };
+  }
+
+  return {
+    props: { sessionData: session },
+  };
+}


### PR DESCRIPTION
로그인 하지 않은 경우 로그인 페이지로 리다렉트 하는 코드를 수정했습니다.
원래는 이걸 마지막에 구현하려고 했는데, ,sessionData 의 null check 가 너무 많아 코드 수정이 너무 어렵더라구요..
이 수정 이후 sessinoData 는 null check 을 하지 않아도 됩니다. 

핵심 코드는 `getServerSideSessionPropsOrRedirect` 함수와, Server side prop 을 활용한 페이지 export 함수의 signature 수정입니다. 